### PR TITLE
Nitpick: Fix spelling of training

### DIFF
--- a/workshops/Molecular-property-prediction/hiv-inhibitor-prediction-dgl/molecule-hiv-inhibitor-prediction-sagemaker.ipynb
+++ b/workshops/Molecular-property-prediction/hiv-inhibitor-prediction-dgl/molecule-hiv-inhibitor-prediction-sagemaker.ipynb
@@ -821,7 +821,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trial_name = \"hiv-inhibitor-prediction-trainning-{}-{}\".format(hyperparameters[\"gnn-model-name\"], time.strftime(\"%m-%d-%Y-%H-%M-%S\"))\n",
+    "trial_name = \"hiv-inhibitor-prediction-training-{}-{}\".format(hyperparameters[\"gnn-model-name\"], time.strftime(\"%m-%d-%Y-%H-%M-%S\"))\n",
     "trial = experiment.create_trial(trial_name=trial_name)"
    ]
   },
@@ -904,7 +904,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#model_data='s3://sagemaker-us-west-2-431678540810/tr-hiv-inhibitor-prediction-trainning-GCN-p-02-27-2022-22-25-51/output/model.tar.gz'\n",
+    "#model_data='s3://sagemaker-us-west-2-431678540810/tr-hiv-inhibitor-prediction-training-GCN-p-02-27-2022-22-25-51/output/model.tar.gz'\n",
     "model_data = estimator.model_data\n",
     "print(\"Stored {} as model_data\".format(model_data))"
    ]


### PR DESCRIPTION
Fix names which used `trainning` to `training`.

*Issue #, if available:* None n/a

*Description of changes:*

Fixes names used in the notebook which refer to training data as `trainning` instead of the generally accepted spelling of `training`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
